### PR TITLE
Make event description URLs clickable across all event views

### DIFF
--- a/akce.html
+++ b/akce.html
@@ -143,13 +143,19 @@
 						<strong>${a.nazev}</strong>
 						<div class="akce-meta">📅 ${formatDate(a.datum)}${a.cas ? ' v ' + a.cas : ''}</div>
 						${a.misto ? '<div class="akce-meta">📍 ' + a.misto + '</div>' : ''}
-						${a.popis ? '<div class="akce-popis">' + a.popis + '</div>' : ''}
+						${a.popis ? '<div class="akce-popis">' + parseLinks(a.popis) + '</div>' : ''}
 					</li>
 				`).join('');
 			}
 
 			function formatDate(d) {
 				return new Date(`${d}T00:00`).toLocaleDateString('cs-CZ');
+			}
+
+			function parseLinks(text) {
+				if (!text) return '';
+				const urlRegex = /(https?:\/\/[^\s]+)/g;
+				return text.replace(urlRegex, url => `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`);
 			}
 		</script>
 	</body>

--- a/aktuality.html
+++ b/aktuality.html
@@ -74,6 +74,12 @@
 				return new Date(`${a.datum}T${a.cas || '23:59'}`);
 			}
 
+			function parseLinks(text) {
+				if (!text) return '';
+				const urlRegex = /(https?:\/\/[^\s]+)/g;
+				return text.replace(urlRegex, url => `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`);
+			}
+
 			function loadNextEvent() {
 				fetch(API)
 					.then(r => r.json())
@@ -99,7 +105,7 @@
 
 						document.getElementById('next-event').innerHTML = `
 							<strong>${event.nazev}</strong><br/>
-							${dateStr}${timeStr}${location}${event.popis ? '<br/>' + event.popis : ''}<br/>
+							${dateStr}${timeStr}${location}${event.popis ? '<br/>' + parseLinks(event.popis) : ''}<br/>
 							<a href="akce.html">Více v Akcích</a>.
 						`;
 					})

--- a/index.html
+++ b/index.html
@@ -155,6 +155,12 @@
 						return new Date(`${a.datum}T${a.cas || '23:59'}`);
 					}
 
+					function parseLinks(text) {
+						if (!text) return '';
+						const urlRegex = /(https?:\/\/[^\s]+)/g;
+						return text.replace(urlRegex, url => `<a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a>`);
+					}
+
 					function renderUpcoming(html) {
 						if (cont) cont.innerHTML = html;
 					}
@@ -176,7 +182,7 @@
 							const dateStr = eventDate.toLocaleDateString('cs-CZ');
 							const timeStr = nextEvent.cas ? ` v ${nextEvent.cas}` : '';
 							const locationStr = nextEvent.misto ? `, ${nextEvent.misto}` : '';
-							const description = nextEvent.popis ? '<br/>' + nextEvent.popis : '';
+							const description = nextEvent.popis ? '<br/>' + parseLinks(nextEvent.popis) : '';
 
 							renderUpcoming(`
 								<p>

--- a/naseAkce.html
+++ b/naseAkce.html
@@ -267,7 +267,7 @@ function renderList(id, data) {
         ${isPublic ? '🌍 Veřejná akce' : '🔒 Interní akce'}
       </div>
 
-      <div>${a.popis || ''}</div>
+      <div>${parseLinks(a.popis || '')}</div>
 
       <div class="akce-actions">
 	<button class="publish-btn ${isPublic ? 'published' : ''}" data-id="${a.id}" data-public="${isPublic ? 1 : 0}">
@@ -400,7 +400,7 @@ function parseLinks(text) {
   const urlRegex = /(https?:\/\/[^\s]+)/g;
   
   return text.replace(urlRegex, (url) => {
-    return `<a href="${url}" target="_blank" style="color: #00ff64; text-decoration: underline;">${url}</a>`;
+    return `<a href="${url}" target="_blank" rel="noopener noreferrer" style="color: #00ff64; text-decoration: underline;">${url}</a>`;
   });
 }
 </script>


### PR DESCRIPTION
### Motivation
- Ensure that URLs typed into an event `popis` become active links everywhere the event is shown (editor page, events list, aktuality and homepage). 
- The helper `parseLinks()` already existed but was not used when composing `innerHTML`, so plain URLs were rendered as text. 
- Keep UX consistent between admin/editor and public pages so adding a link once works "naskrz" (everywhere). 

### Description
- Use `parseLinks(a.popis)` when rendering event descriptions in `naseAkce.html` so admin/editor cards show clickable links. 
- Update public renderers to call `parseLinks(...)` in `akce.html`, `aktuality.html`, and `index.html` so lists, aktuality and upcoming-event blocks render links. 
- Add/restore `parseLinks` implementations where needed and include `rel="noopener noreferrer"` on links opened with `target="_blank"`. 
- Changes committed under message `Fix clickable event links across all event views` and prepared as a PR. 

### Testing
- Searched repository to verify usage with `rg -n "parseLinks\(|a\.popis|nextEvent\.popis|event\.popis"` and confirmed updated sites; search succeeded. 
- Inspected diffs with `git diff` to confirm replacements in `naseAkce.html`, `akce.html`, `index.html`, and `aktuality.html`; diff inspection succeeded. 
- Committed changes with `git commit -m "Fix clickable event links across all event views"` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f859eb5880832f8b6467d6f149d7c5)