### PR TITLE
Convert plain URLs in event descriptions to labeled clickable links

### DIFF
--- a/akce.html
+++ b/akce.html
@@ -143,13 +143,26 @@
 						<strong>${a.nazev}</strong>
 						<div class="akce-meta">📅 ${formatDate(a.datum)}${a.cas ? ' v ' + a.cas : ''}</div>
 						${a.misto ? '<div class="akce-meta">📍 ' + a.misto + '</div>' : ''}
-						${a.popis ? '<div class="akce-popis">' + a.popis + '</div>' : ''}
+						${a.popis ? '<div class="akce-popis">' + parseLinks(a.popis) + '</div>' : ''}
 					</li>
 				`).join('');
 			}
 
 			function formatDate(d) {
 				return new Date(`${d}T00:00`).toLocaleDateString('cs-CZ');
+			}
+
+			function parseLinks(text) {
+				if (!text) return '';
+				const urlRegex = /(https?:\/\/[^\s]+)/g;
+				return text.replace(urlRegex, url => {
+					let safeLabel = 'Odkaz';
+					try {
+						const parsed = new URL(url);
+						safeLabel = parsed.hostname.replace(/^www\./, '') + (parsed.pathname && parsed.pathname !== '/' ? '/…' : '');
+					} catch (_) {}
+					return `<a href="${url}" target="_blank" rel="noopener noreferrer">${safeLabel}</a>`;
+				});
 			}
 		</script>
 	</body>

--- a/aktuality.html
+++ b/aktuality.html
@@ -74,6 +74,19 @@
 				return new Date(`${a.datum}T${a.cas || '23:59'}`);
 			}
 
+			function parseLinks(text) {
+				if (!text) return '';
+				const urlRegex = /(https?:\/\/[^\s]+)/g;
+				return text.replace(urlRegex, url => {
+					let safeLabel = 'Odkaz';
+					try {
+						const parsed = new URL(url);
+						safeLabel = parsed.hostname.replace(/^www\./, '') + (parsed.pathname && parsed.pathname !== '/' ? '/…' : '');
+					} catch (_) {}
+					return `<a href="${url}" target="_blank" rel="noopener noreferrer">${safeLabel}</a>`;
+				});
+			}
+
 			function loadNextEvent() {
 				fetch(API)
 					.then(r => r.json())
@@ -99,7 +112,7 @@
 
 						document.getElementById('next-event').innerHTML = `
 							<strong>${event.nazev}</strong><br/>
-							${dateStr}${timeStr}${location}${event.popis ? '<br/>' + event.popis : ''}<br/>
+							${dateStr}${timeStr}${location}${event.popis ? '<br/>' + parseLinks(event.popis) : ''}<br/>
 							<a href="akce.html">Více v Akcích</a>.
 						`;
 					})

--- a/index.html
+++ b/index.html
@@ -155,6 +155,19 @@
 						return new Date(`${a.datum}T${a.cas || '23:59'}`);
 					}
 
+					function parseLinks(text) {
+						if (!text) return '';
+						const urlRegex = /(https?:\/\/[^\s]+)/g;
+						return text.replace(urlRegex, url => {
+							let safeLabel = 'Odkaz';
+							try {
+								const parsed = new URL(url);
+								safeLabel = parsed.hostname.replace(/^www\./, '') + (parsed.pathname && parsed.pathname !== '/' ? '/…' : '');
+							} catch (_) {}
+							return `<a href="${url}" target="_blank" rel="noopener noreferrer">${safeLabel}</a>`;
+						});
+					}
+
 					function renderUpcoming(html) {
 						if (cont) cont.innerHTML = html;
 					}
@@ -176,7 +189,7 @@
 							const dateStr = eventDate.toLocaleDateString('cs-CZ');
 							const timeStr = nextEvent.cas ? ` v ${nextEvent.cas}` : '';
 							const locationStr = nextEvent.misto ? `, ${nextEvent.misto}` : '';
-							const description = nextEvent.popis ? '<br/>' + nextEvent.popis : '';
+							const description = nextEvent.popis ? '<br/>' + parseLinks(nextEvent.popis) : '';
 
 							renderUpcoming(`
 								<p>

--- a/naseAkce.html
+++ b/naseAkce.html
@@ -267,7 +267,7 @@ function renderList(id, data) {
         ${isPublic ? '🌍 Veřejná akce' : '🔒 Interní akce'}
       </div>
 
-      <div>${a.popis || ''}</div>
+      <div>${parseLinks(a.popis || '')}</div>
 
       <div class="akce-actions">
 	<button class="publish-btn ${isPublic ? 'published' : ''}" data-id="${a.id}" data-public="${isPublic ? 1 : 0}">
@@ -400,7 +400,12 @@ function parseLinks(text) {
   const urlRegex = /(https?:\/\/[^\s]+)/g;
   
   return text.replace(urlRegex, (url) => {
-    return `<a href="${url}" target="_blank" style="color: #00ff64; text-decoration: underline;">${url}</a>`;
+    let safeLabel = 'Odkaz';
+    try {
+      const parsed = new URL(url);
+      safeLabel = parsed.hostname.replace(/^www\./, '') + (parsed.pathname && parsed.pathname !== '/' ? '/…' : '');
+    } catch (_) {}
+    return `<a href="${url}" target="_blank" rel="noopener noreferrer" style="color: #00ff64; text-decoration: underline;">${safeLabel}</a>`;
   });
 }
 </script>


### PR DESCRIPTION
### Motivation
- Improve user experience by rendering plain text URLs in event descriptions as clickable links across event pages.
- Avoid displaying raw long URLs and provide concise, readable labels for external links while adding safe attributes.

### Description
- Introduced a reusable `parseLinks` function in `akce.html`, `aktuality.html`, `index.html`, and `naseAkce.html` that detects `http(s)` URLs and replaces them with `<a>` tags.
- Replaced direct insertion of `a.popis` with `parseLinks(a.popis)` (and equivalents) so descriptions render clickable, labeled links instead of raw URLs.
- `parseLinks` generates a short, user-friendly label from `new URL(url).hostname` (stripping `www.` and showing `'/…'` for non-root paths) and adds `target="_blank" rel="noopener noreferrer"` for safety.
- Preserved existing inline link styling in `naseAkce.html` while improving link text and security attributes.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f859eb5880832f8b6467d6f149d7c5)