### PR TITLE
Convert plaintext URLs to safe clickable links in event descriptions and clean up album page

### DIFF
--- a/akce.html
+++ b/akce.html
@@ -143,13 +143,26 @@
 						<strong>${a.nazev}</strong>
 						<div class="akce-meta">📅 ${formatDate(a.datum)}${a.cas ? ' v ' + a.cas : ''}</div>
 						${a.misto ? '<div class="akce-meta">📍 ' + a.misto + '</div>' : ''}
-						${a.popis ? '<div class="akce-popis">' + a.popis + '</div>' : ''}
+						${a.popis ? '<div class="akce-popis">' + parseLinks(a.popis) + '</div>' : ''}
 					</li>
 				`).join('');
 			}
 
 			function formatDate(d) {
 				return new Date(`${d}T00:00`).toLocaleDateString('cs-CZ');
+			}
+
+			function parseLinks(text) {
+				if (!text) return '';
+				const urlRegex = /(https?:\/\/[^\s]+)/g;
+				return text.replace(urlRegex, url => {
+					let safeLabel = 'Odkaz';
+					try {
+						const parsed = new URL(url);
+						safeLabel = parsed.hostname.replace(/^www\./, '') + (parsed.pathname && parsed.pathname !== '/' ? '/…' : '');
+					} catch (_) {}
+					return `<a href="${url}" target="_blank" rel="noopener noreferrer">${safeLabel}</a>`;
+				});
 			}
 		</script>
 	</body>

--- a/aktuality.html
+++ b/aktuality.html
@@ -74,6 +74,19 @@
 				return new Date(`${a.datum}T${a.cas || '23:59'}`);
 			}
 
+			function parseLinks(text) {
+				if (!text) return '';
+				const urlRegex = /(https?:\/\/[^\s]+)/g;
+				return text.replace(urlRegex, url => {
+					let safeLabel = 'Odkaz';
+					try {
+						const parsed = new URL(url);
+						safeLabel = parsed.hostname.replace(/^www\./, '') + (parsed.pathname && parsed.pathname !== '/' ? '/…' : '');
+					} catch (_) {}
+					return `<a href="${url}" target="_blank" rel="noopener noreferrer">${safeLabel}</a>`;
+				});
+			}
+
 			function loadNextEvent() {
 				fetch(API)
 					.then(r => r.json())
@@ -99,7 +112,7 @@
 
 						document.getElementById('next-event').innerHTML = `
 							<strong>${event.nazev}</strong><br/>
-							${dateStr}${timeStr}${location}${event.popis ? '<br/>' + event.popis : ''}<br/>
+							${dateStr}${timeStr}${location}${event.popis ? '<br/>' + parseLinks(event.popis) : ''}<br/>
 							<a href="akce.html">Více v Akcích</a>.
 						`;
 					})

--- a/alba.html
+++ b/alba.html
@@ -56,80 +56,60 @@
 								<strong>Tomáš Ledvina</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/tomas-ledvina-1066762" target="_blank" rel="noopener">Text písně – Tomáš Ledvina</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 							<li>
 								<strong>Procházka Růžovým Sadem</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/prochazka-ruzovym-sadem-1066766" target="_blank" rel="noopener">Text písně – Procházka Růžovým Sadem</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 							<li>
 								<strong>Tři Telata</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/tri-telata-1066769" target="_blank" rel="noopener">Text písně – Tři Telata</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 							<li>
 								<strong>Nebulant</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/nebulant-1066842" target="_blank" rel="noopener">Text písně – Nebulant</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 							<li>
 								<strong>Radek Černý</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/radek-cerny-1066845" target="_blank" rel="noopener">Text písně – Radek Černý</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 							<li>
 								<strong>Klobukový v A dur</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/klobukovy-v-a-dur-1066846" target="_blank" rel="noopener">Text písně – Klobukový v A dur</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 							<li>
 								<strong>Lidovky 2</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/lidovky-1066852" target="_blank" rel="noopener">Text písně – Lidovky 2</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 							<li>
 								<strong>Francuzskaja koljadka</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/francuzskaja-koljadka-1066958" target="_blank" rel="noopener">Text písně – Francuzskaja koljadka</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 							<li>
 								<strong>Veselá Příhoda v Lese</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/vesela-prihoda-v-lese-1066856" target="_blank" rel="noopener">Text písně – Veselá Příhoda v Lese</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 							<li>
 								<strong>Óda na Život</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/oda-na-zivot-1066857" target="_blank" rel="noopener">Text písně – Óda na Život</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 						</ul>
@@ -138,29 +118,7 @@
 					<section class="box">
 						<h2>Škaredá žena</h2>
 						<span class="image fit uniform"><img src="images/pic13.jpg" alt="Obal alba Škaredá žena" /></span>
-						<p>Aktuální album. Popis alba a příběh jeho vzniku doplníme.</p>
-						<ul class="actions">
-							<li><a href="merch.html" class="button primary">CD v Merch</a></li>
-						</ul>
-						<h3>Seznam písní</h3>
-						<ul>
-							<li>
-								<strong>Název písně 1</strong>
-								<ul>
-									<li>Text: <em>Text písně bude doplněn.</em></li>
-									<li>Odkaz na poslech: <em>(YouTube/Bandcamp/Spotify odkaz)</em></li>
-									<li>Historie písničky – vznik, lore: <em>Krátký příběh, inspirace, okolnosti vzniku…</em></li>
-								</ul>
-							</li>
-							<li>
-								<strong>Název písně 2</strong>
-								<ul>
-									<li>Text: <em>Text písně bude doplněn.</em></li>
-									<li>Odkaz na poslech: <em>(odkaz)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
-								</ul>
-							</li>
-						</ul>
+						<p>Jde o prvotinu, která je k poslechu na YouTube.</p>
 					</section>
 				</div>
 			</div>

--- a/index.html
+++ b/index.html
@@ -155,6 +155,19 @@
 						return new Date(`${a.datum}T${a.cas || '23:59'}`);
 					}
 
+					function parseLinks(text) {
+						if (!text) return '';
+						const urlRegex = /(https?:\/\/[^\s]+)/g;
+						return text.replace(urlRegex, url => {
+							let safeLabel = 'Odkaz';
+							try {
+								const parsed = new URL(url);
+								safeLabel = parsed.hostname.replace(/^www\./, '') + (parsed.pathname && parsed.pathname !== '/' ? '/…' : '');
+							} catch (_) {}
+							return `<a href="${url}" target="_blank" rel="noopener noreferrer">${safeLabel}</a>`;
+						});
+					}
+
 					function renderUpcoming(html) {
 						if (cont) cont.innerHTML = html;
 					}
@@ -176,7 +189,7 @@
 							const dateStr = eventDate.toLocaleDateString('cs-CZ');
 							const timeStr = nextEvent.cas ? ` v ${nextEvent.cas}` : '';
 							const locationStr = nextEvent.misto ? `, ${nextEvent.misto}` : '';
-							const description = nextEvent.popis ? '<br/>' + nextEvent.popis : '';
+							const description = nextEvent.popis ? '<br/>' + parseLinks(nextEvent.popis) : '';
 
 							renderUpcoming(`
 								<p>

--- a/naseAkce.html
+++ b/naseAkce.html
@@ -267,7 +267,7 @@ function renderList(id, data) {
         ${isPublic ? '🌍 Veřejná akce' : '🔒 Interní akce'}
       </div>
 
-      <div>${a.popis || ''}</div>
+      <div>${parseLinks(a.popis || '')}</div>
 
       <div class="akce-actions">
 	<button class="publish-btn ${isPublic ? 'published' : ''}" data-id="${a.id}" data-public="${isPublic ? 1 : 0}">
@@ -400,7 +400,12 @@ function parseLinks(text) {
   const urlRegex = /(https?:\/\/[^\s]+)/g;
   
   return text.replace(urlRegex, (url) => {
-    return `<a href="${url}" target="_blank" style="color: #00ff64; text-decoration: underline;">${url}</a>`;
+    let safeLabel = 'Odkaz';
+    try {
+      const parsed = new URL(url);
+      safeLabel = parsed.hostname.replace(/^www\./, '') + (parsed.pathname && parsed.pathname !== '/' ? '/…' : '');
+    } catch (_) {}
+    return `<a href="${url}" target="_blank" rel="noopener noreferrer" style="color: #00ff64; text-decoration: underline;">${safeLabel}</a>`;
   });
 }
 </script>


### PR DESCRIPTION
### Motivation
- Improve presentation and safety of event and news descriptions by converting plaintext URLs into user-friendly clickable links.
- Standardize link rendering across pages and add `rel="noopener noreferrer"` and `target="_blank"` to external links for security.
- Remove placeholder/duplicate content on the album page to simplify the page copy.

### Description
- Added a `parseLinks` function to multiple pages (`akce.html`, `aktuality.html`, `index.html`, `naseAkce.html`) that detects `http(s)://` URLs and replaces them with anchor tags showing a compact hostname label.
- Replaced raw description output with `parseLinks(...)` in event listings and previews so descriptions render safe, clickable links instead of plain URLs.
- Enhanced the admin/event list `parseLinks` usage to return a styled anchor and include `rel="noopener noreferrer"` and `target="_blank"` for security and UX.
- Simplified `alba.html` by removing many placeholder list items and clarifying album copy.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f859eb5880832f8b6467d6f149d7c5)