### PR TITLE
Keep events current through day end and auto-link URLs in event descriptions; copy/content updates

### DIFF
--- a/akce.html
+++ b/akce.html
@@ -70,7 +70,7 @@
 					<p>Všechny zveřejněné akce jsou zde.</p>
 
 					<section>
-						<h2>Současné akce</h2>
+						<h2>Aktuální akce</h2>
 						<ul id="current-akce" class="akce-list">
 							<li><p>Načítám...</p></li>
 						</ul>
@@ -106,6 +106,10 @@
 				return new Date(`${a.datum}T${a.cas || '23:59'}`);
 			}
 
+			function toEventDayEnd(a) {
+				return new Date(`${a.datum}T23:59:59`);
+			}
+
 			function loadAkce() {
 				fetch(API)
 					.then(r => r.json())
@@ -117,7 +121,7 @@
 						data
 							.filter(isPublicEvent)
 							.forEach(a => {
-								const d = toEventDate(a);
+								const d = toEventDayEnd(a);
 								if (d >= now) current.push(a);
 								else past.push(a);
 							});
@@ -143,13 +147,26 @@
 						<strong>${a.nazev}</strong>
 						<div class="akce-meta">📅 ${formatDate(a.datum)}${a.cas ? ' v ' + a.cas : ''}</div>
 						${a.misto ? '<div class="akce-meta">📍 ' + a.misto + '</div>' : ''}
-						${a.popis ? '<div class="akce-popis">' + a.popis + '</div>' : ''}
+						${a.popis ? '<div class="akce-popis">' + parseLinks(a.popis) + '</div>' : ''}
 					</li>
 				`).join('');
 			}
 
 			function formatDate(d) {
 				return new Date(`${d}T00:00`).toLocaleDateString('cs-CZ');
+			}
+
+			function parseLinks(text) {
+				if (!text) return '';
+				const urlRegex = /(https?:\/\/[^\s]+)/g;
+				return text.replace(urlRegex, url => {
+					let safeLabel = 'Odkaz';
+					try {
+						const parsed = new URL(url);
+						safeLabel = parsed.hostname.replace(/^www\./, '') + (parsed.pathname && parsed.pathname !== '/' ? '/…' : '');
+					} catch (_) {}
+					return `<a href="${url}" target="_blank" rel="noopener noreferrer">${safeLabel}</a>`;
+				});
 			}
 		</script>
 	</body>

--- a/aktuality.html
+++ b/aktuality.html
@@ -43,7 +43,7 @@
 					<p>Zde najdete nejnovější informace o koncertech, akcích a vydáních.</p>
 
 					<section>
-						<h2>Nejnovější</h2>
+						<h2>Aktuální akce</h2>
 						<ul class="alt" id="next-event-container">
 							<li id="next-event">
 								<strong>Načítám...</strong>
@@ -74,13 +74,30 @@
 				return new Date(`${a.datum}T${a.cas || '23:59'}`);
 			}
 
+			function toEventDayEnd(a) {
+				return new Date(`${a.datum}T23:59:59`);
+			}
+
+			function parseLinks(text) {
+				if (!text) return '';
+				const urlRegex = /(https?:\/\/[^\s]+)/g;
+				return text.replace(urlRegex, url => {
+					let safeLabel = 'Odkaz';
+					try {
+						const parsed = new URL(url);
+						safeLabel = parsed.hostname.replace(/^www\./, '') + (parsed.pathname && parsed.pathname !== '/' ? '/…' : '');
+					} catch (_) {}
+					return `<a href="${url}" target="_blank" rel="noopener noreferrer">${safeLabel}</a>`;
+				});
+			}
+
 			function loadNextEvent() {
 				fetch(API)
 					.then(r => r.json())
 					.then(data => {
 						const now = new Date();
 						const upcomingEvents = data
-							.filter(a => isPublicEvent(a) && toEventDate(a) >= now)
+							.filter(a => isPublicEvent(a) && toEventDayEnd(a) >= now)
 							.sort((a, b) => toEventDate(a) - toEventDate(b));
 
 						if (upcomingEvents.length === 0) {
@@ -99,7 +116,7 @@
 
 						document.getElementById('next-event').innerHTML = `
 							<strong>${event.nazev}</strong><br/>
-							${dateStr}${timeStr}${location}${event.popis ? '<br/>' + event.popis : ''}<br/>
+							${dateStr}${timeStr}${location}${event.popis ? '<br/>' + parseLinks(event.popis) : ''}<br/>
 							<a href="akce.html">Více v Akcích</a>.
 						`;
 					})

--- a/alba.html
+++ b/alba.html
@@ -56,80 +56,60 @@
 								<strong>Tomáš Ledvina</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/tomas-ledvina-1066762" target="_blank" rel="noopener">Text písně – Tomáš Ledvina</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 							<li>
 								<strong>Procházka Růžovým Sadem</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/prochazka-ruzovym-sadem-1066766" target="_blank" rel="noopener">Text písně – Procházka Růžovým Sadem</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 							<li>
 								<strong>Tři Telata</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/tri-telata-1066769" target="_blank" rel="noopener">Text písně – Tři Telata</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 							<li>
 								<strong>Nebulant</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/nebulant-1066842" target="_blank" rel="noopener">Text písně – Nebulant</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 							<li>
 								<strong>Radek Černý</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/radek-cerny-1066845" target="_blank" rel="noopener">Text písně – Radek Černý</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 							<li>
 								<strong>Klobukový v A dur</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/klobukovy-v-a-dur-1066846" target="_blank" rel="noopener">Text písně – Klobukový v A dur</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 							<li>
 								<strong>Lidovky 2</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/lidovky-1066852" target="_blank" rel="noopener">Text písně – Lidovky 2</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 							<li>
 								<strong>Francuzskaja koljadka</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/francuzskaja-koljadka-1066958" target="_blank" rel="noopener">Text písně – Francuzskaja koljadka</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 							<li>
 								<strong>Veselá Příhoda v Lese</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/vesela-prihoda-v-lese-1066856" target="_blank" rel="noopener">Text písně – Veselá Příhoda v Lese</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 							<li>
 								<strong>Óda na Život</strong>
 								<ul>
 									<li>Text: <a href="https://www.karaoketexty.cz/texty-pisni/heja-boys/oda-na-zivot-1066857" target="_blank" rel="noopener">Text písně – Óda na Život</a></li>
-									<li>Odkaz na poslech: <em>(odkaz na konkrétní track)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
 								</ul>
 							</li>
 						</ul>
@@ -138,29 +118,7 @@
 					<section class="box">
 						<h2>Škaredá žena</h2>
 						<span class="image fit uniform"><img src="images/pic13.jpg" alt="Obal alba Škaredá žena" /></span>
-						<p>Aktuální album. Popis alba a příběh jeho vzniku doplníme.</p>
-						<ul class="actions">
-							<li><a href="merch.html" class="button primary">CD v Merch</a></li>
-						</ul>
-						<h3>Seznam písní</h3>
-						<ul>
-							<li>
-								<strong>Název písně 1</strong>
-								<ul>
-									<li>Text: <em>Text písně bude doplněn.</em></li>
-									<li>Odkaz na poslech: <em>(YouTube/Bandcamp/Spotify odkaz)</em></li>
-									<li>Historie písničky – vznik, lore: <em>Krátký příběh, inspirace, okolnosti vzniku…</em></li>
-								</ul>
-							</li>
-							<li>
-								<strong>Název písně 2</strong>
-								<ul>
-									<li>Text: <em>Text písně bude doplněn.</em></li>
-									<li>Odkaz na poslech: <em>(odkaz)</em></li>
-									<li>Historie písničky – vznik, lore: <em>…</em></li>
-								</ul>
-							</li>
-						</ul>
+						<p>Jde o prvotinu, která je k poslechu na YouTube.</p>
 					</section>
 				</div>
 			</div>

--- a/index.html
+++ b/index.html
@@ -57,9 +57,9 @@
  						</header>
 
  						<section class="box clickable" data-href="akce.html" id="upcoming">
- 							<h2>Nejbližší akce</h2>
+ 							<h2>Aktuální akce</h2>
  							<div id="upcoming-content">
- 								<p>Načítám nejbližší akci z <a href="aktuality.html">Aktualit</a>…</p>
+ 								<p>Načítám aktuální akci z <a href="aktuality.html">Aktualit</a>…</p>
  							</div>
  						</section>
 
@@ -155,6 +155,23 @@
 						return new Date(`${a.datum}T${a.cas || '23:59'}`);
 					}
 
+					function toEventDayEnd(a) {
+						return new Date(`${a.datum}T23:59:59`);
+					}
+
+					function parseLinks(text) {
+						if (!text) return '';
+						const urlRegex = /(https?:\/\/[^\s]+)/g;
+						return text.replace(urlRegex, url => {
+							let safeLabel = 'Odkaz';
+							try {
+								const parsed = new URL(url);
+								safeLabel = parsed.hostname.replace(/^www\./, '') + (parsed.pathname && parsed.pathname !== '/' ? '/…' : '');
+							} catch (_) {}
+							return `<a href="${url}" target="_blank" rel="noopener noreferrer">${safeLabel}</a>`;
+						});
+					}
+
 					function renderUpcoming(html) {
 						if (cont) cont.innerHTML = html;
 					}
@@ -164,7 +181,7 @@
 						.then(data => {
 							const now = new Date();
 							const nextEvent = data
-								.filter(a => isPublicEvent(a) && toEventDate(a) >= now)
+								.filter(a => isPublicEvent(a) && toEventDayEnd(a) >= now)
 								.sort((a, b) => toEventDate(a) - toEventDate(b))[0];
 
 							if (!nextEvent) {
@@ -176,7 +193,7 @@
 							const dateStr = eventDate.toLocaleDateString('cs-CZ');
 							const timeStr = nextEvent.cas ? ` v ${nextEvent.cas}` : '';
 							const locationStr = nextEvent.misto ? `, ${nextEvent.misto}` : '';
-							const description = nextEvent.popis ? '<br/>' + nextEvent.popis : '';
+							const description = nextEvent.popis ? '<br/>' + parseLinks(nextEvent.popis) : '';
 
 							renderUpcoming(`
 								<p>

--- a/naseAkce.html
+++ b/naseAkce.html
@@ -155,7 +155,7 @@
 
 <!-- LIST -->
 <section>
-  <div class="section-title">📅 Nadcházející akce</div>
+  <div class="section-title">📅 Aktuální akce</div>
   <div id="future-list"></div>
 
   <div class="section-title">📁 Proběhlé akce</div>
@@ -197,6 +197,10 @@ function toEventDate(a) {
   return new Date(`${a.datum}T${a.cas || '23:59'}`);
 }
 
+function toEventDayEnd(a) {
+  return new Date(`${a.datum}T23:59:59`);
+}
+
 function resetFormState(form) {
   form.reset();
   editingId = null;
@@ -220,7 +224,7 @@ function loadAkce() {
       const past = [];
 
       data.forEach(a => {
-        const d = toEventDate(a);
+        const d = toEventDayEnd(a);
         if (d >= now) future.push(a);
         else past.push(a);
       });
@@ -267,7 +271,7 @@ function renderList(id, data) {
         ${isPublic ? '🌍 Veřejná akce' : '🔒 Interní akce'}
       </div>
 
-      <div>${a.popis || ''}</div>
+      <div>${parseLinks(a.popis || '')}</div>
 
       <div class="akce-actions">
 	<button class="publish-btn ${isPublic ? 'published' : ''}" data-id="${a.id}" data-public="${isPublic ? 1 : 0}">
@@ -400,7 +404,12 @@ function parseLinks(text) {
   const urlRegex = /(https?:\/\/[^\s]+)/g;
   
   return text.replace(urlRegex, (url) => {
-    return `<a href="${url}" target="_blank" style="color: #00ff64; text-decoration: underline;">${url}</a>`;
+    let safeLabel = 'Odkaz';
+    try {
+      const parsed = new URL(url);
+      safeLabel = parsed.hostname.replace(/^www\./, '') + (parsed.pathname && parsed.pathname !== '/' ? '/…' : '');
+    } catch (_) {}
+    return `<a href="${url}" target="_blank" rel="noopener noreferrer" style="color: #00ff64; text-decoration: underline;">${safeLabel}</a>`;
   });
 }
 </script>


### PR DESCRIPTION
### Motivation
- Ensure events without a specific time (or with a time later in the day) are treated as current for the entire day so they don't prematurely move to past lists.
- Improve usability by converting plain URLs in event descriptions into clickable, safe links with concise labels.
- Clean up several UI labels and album content to be clearer and more consistent across pages.

### Description
- Added `toEventDayEnd` helper and switched event filtering to use the day's end timestamp so events are considered current until `23:59:59` across `akce.html`, `aktuality.html`, `index.html` and `naseAkce.html`.
- Implemented `parseLinks` in multiple pages to detect `http(s)://` URLs in event descriptions and render them as `<a>` tags with `rel="noopener noreferrer"`, `target="_blank"` and a hostname-based short label.
- Replaced several headings and copy strings (e.g. "Nejbližší akce"/"Nejnovější"/"Nadcházející akce" → "Aktuální akce") for consistency and simplified album content in `alba.html`.
- Updated admin event list in `naseAkce.html` to use `parseLinks` and minor UI tweaks for publish button data handling.

### Testing
- No automated tests were present or executed for these static/UI changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f859eb5880832f8b6467d6f149d7c5)