### PR TITLE
Add QR code to account balance panel

### DIFF
--- a/assets/css/nase-akce.css
+++ b/assets/css/nase-akce.css
@@ -190,6 +190,31 @@ button:hover {
   font-weight: 800;
 }
 
+.account-side {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.85em;
+}
+
+.account-qr-link {
+  display: block;
+  flex: 0 0 auto;
+  line-height: 0;
+}
+
+.account-qr {
+  display: block;
+  width: 4.6em;
+  height: 4.6em;
+  padding: 0.28em;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 10px;
+  background: #fff;
+  object-fit: contain;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.18);
+}
+
 .account-updated {
   max-width: 15em;
   text-align: right;
@@ -292,6 +317,7 @@ button:hover {
 @media screen and (max-width: 736px) {
   .page-title-row,
   .account-summary,
+  .account-side,
   .account-form,
   .past-section-header {
     flex-direction: column;
@@ -307,6 +333,10 @@ button:hover {
   .account-form button {
     width: 100%;
     max-width: none;
+  }
+
+  .account-side {
+    width: 100%;
   }
 
   .account-updated {

--- a/naseAkce.html
+++ b/naseAkce.html
@@ -72,7 +72,12 @@
                   <div id="account-balance" class="account-balance">Načítám…</div>
                 </div>
               </div>
-              <div id="account-updated" class="account-updated"></div>
+              <div class="account-side">
+                <a href="images/qr_code.jpg" class="account-qr-link" target="_blank" rel="noopener" aria-label="Otevřít QR kód k platbě v plné velikosti">
+                  <img src="images/qr_code.jpg" alt="QR kód k platbě na kapelní účet" class="account-qr">
+                </a>
+                <div id="account-updated" class="account-updated"></div>
+              </div>
             </div>
             <form id="account-form" class="account-form" style="display:none;">
               <label for="account-amount">Nový stav</label>


### PR DESCRIPTION
### Motivation
- Make the QR code from `images/qr_code.jpg` visible and easily openable from the expandable "Stav účtu" panel so people can pay to the band account without leaving the page.

### Description
- Inserted a clickable QR markup into `naseAkce.html` inside the account panel (`<a href="images/qr_code.jpg"><img class="account-qr">`) that opens the full image in a new tab and moved the update timestamp into the same side container.
- Added compact styling and layout in `assets/css/nase-akce.css` (`.account-side`, `.account-qr-link`, `.account-qr`) and updated the mobile media query so the QR stacks cleanly under the balance on small screens.

### Testing
- Ran `git diff --check` which reported no issues.
- Parsed `naseAkce.html` with Python's `HTMLParser` which succeeded.
- Ran Python assertions to confirm `images/qr_code.jpg` exists and `.account-qr` is present in the CSS, and those checks passed.
- Attempted automated browser/screenshot verification but `playwright` / headless browser was not available in the environment so visual screenshot tests were skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27f18dbc98832fb30cbee0842af875)