### PR TITLE
Add QR support box on homepage and account QR in events page with responsive styles

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3616,3 +3616,45 @@ input[type="button"],
     border-radius: 2px;
     margin-top: 0.3em;
 }
+
+/* Homepage support QR box */
+.support-box {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25em;
+  margin-top: 1.2em;
+  padding: 1em 1.2em;
+  background: rgba(255, 255, 255, 0.94);
+  border: 1px solid rgba(240, 79, 106, 0.18);
+}
+
+.support-box__text {
+  font-size: 1.05em;
+  line-height: 1.35;
+}
+
+.support-box__qr-link {
+  display: block;
+  flex: 0 0 auto;
+  line-height: 0;
+}
+
+.support-box__qr {
+  display: block;
+  width: 5.25em;
+  height: 5.25em;
+  padding: 0.3em;
+  border: 1px solid rgba(88, 88, 88, 0.16);
+  border-radius: 8px;
+  background: #ffffff;
+  object-fit: contain;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.14);
+}
+
+@media screen and (max-width: 736px) {
+  .support-box {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/assets/css/nase-akce.css
+++ b/assets/css/nase-akce.css
@@ -190,6 +190,31 @@ button:hover {
   font-weight: 800;
 }
 
+.account-side {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.85em;
+}
+
+.account-qr-link {
+  display: block;
+  flex: 0 0 auto;
+  line-height: 0;
+}
+
+.account-qr {
+  display: block;
+  width: 4.6em;
+  height: 4.6em;
+  padding: 0.28em;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 10px;
+  background: #fff;
+  object-fit: contain;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.18);
+}
+
 .account-updated {
   max-width: 15em;
   text-align: right;
@@ -292,6 +317,7 @@ button:hover {
 @media screen and (max-width: 736px) {
   .page-title-row,
   .account-summary,
+  .account-side,
   .account-form,
   .past-section-header {
     flex-direction: column;
@@ -307,6 +333,10 @@ button:hover {
   .account-form button {
     width: 100%;
     max-width: none;
+  }
+
+  .account-side {
+    width: 100%;
   }
 
   .account-updated {

--- a/index.html
+++ b/index.html
@@ -64,6 +64,15 @@
  							</div>
  						</section>
 
+						<section class="box support-box" aria-label="Podpora kapely">
+							<div class="support-box__text">
+								<strong>Podpořte nás příspěvkem na rozvoj kapely</strong>
+							</div>
+							<a href="images/qr_code.jpg" class="support-box__qr-link" target="_blank" rel="noopener" aria-label="Otevřít QR kód pro podporu kapely v plné velikosti">
+								<img src="images/qr_code.jpg" alt="QR kód pro příspěvek na rozvoj kapely" class="support-box__qr" />
+							</a>
+						</section>
+
  						<section class="tiles">
 							<article>
 								<span class="image">

--- a/naseAkce.html
+++ b/naseAkce.html
@@ -72,7 +72,12 @@
                   <div id="account-balance" class="account-balance">Načítám…</div>
                 </div>
               </div>
-              <div id="account-updated" class="account-updated"></div>
+              <div class="account-side">
+                <a href="images/qr_code.jpg" class="account-qr-link" target="_blank" rel="noopener" aria-label="Otevřít QR kód k platbě v plné velikosti">
+                  <img src="images/qr_code.jpg" alt="QR kód k platbě na kapelní účet" class="account-qr">
+                </a>
+                <div id="account-updated" class="account-updated"></div>
+              </div>
             </div>
             <form id="account-form" class="account-form" style="display:none;">
               <label for="account-amount">Nový stav</label>


### PR DESCRIPTION
### Motivation
- Provide an accessible QR code for supporters to contribute and expose the same QR prominently in the account/admin area for payments. 
- Ensure the new QR elements have consistent visuals and behave well on small screens.

### Description
- Added a homepage support section in `index.html` using `support-box`, `support-box__text`, and `support-box__qr-link` that links `images/qr_code.jpg` and includes accessible labels. 
- Updated `naseAkce.html` to wrap `#account-updated` in a new `account-side` container and added an `account-qr` image/link to `images/qr_code.jpg` so the account panel exposes the payment QR. 
- Added styling rules in `assets/css/main.css` for the `.support-box` family and a responsive media query, and added `.account-side`, `.account-qr-link`, and `.account-qr` styles plus responsive adjustments to `assets/css/nase-akce.css`. 
- Kept existing accessibility attributes (`aria-label`, `aria-live`) while rearranging markup for layout purposes.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27f18dbc98832fb30cbee0842af875)