### PR TITLE
Add QR payment block to account panel with styling and responsive layout

### DIFF
--- a/assets/css/nase-akce.css
+++ b/assets/css/nase-akce.css
@@ -190,6 +190,31 @@ button:hover {
   font-weight: 800;
 }
 
+.account-side {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.85em;
+}
+
+.account-qr-link {
+  display: block;
+  flex: 0 0 auto;
+  line-height: 0;
+}
+
+.account-qr {
+  display: block;
+  width: 4.6em;
+  height: 4.6em;
+  padding: 0.28em;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 10px;
+  background: #fff;
+  object-fit: contain;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.18);
+}
+
 .account-updated {
   max-width: 15em;
   text-align: right;
@@ -292,6 +317,7 @@ button:hover {
 @media screen and (max-width: 736px) {
   .page-title-row,
   .account-summary,
+  .account-side,
   .account-form,
   .past-section-header {
     flex-direction: column;
@@ -307,6 +333,10 @@ button:hover {
   .account-form button {
     width: 100%;
     max-width: none;
+  }
+
+  .account-side {
+    width: 100%;
   }
 
   .account-updated {

--- a/naseAkce.html
+++ b/naseAkce.html
@@ -72,7 +72,12 @@
                   <div id="account-balance" class="account-balance">Načítám…</div>
                 </div>
               </div>
-              <div id="account-updated" class="account-updated"></div>
+              <div class="account-side">
+                <a href="images/qr_code.jpg" class="account-qr-link" target="_blank" rel="noopener" aria-label="Otevřít QR kód k platbě v plné velikosti">
+                  <img src="images/qr_code.jpg" alt="QR kód k platbě na kapelní účet" class="account-qr">
+                </a>
+                <div id="account-updated" class="account-updated"></div>
+              </div>
             </div>
             <form id="account-form" class="account-form" style="display:none;">
               <label for="account-amount">Nový stav</label>


### PR DESCRIPTION
### Motivation
- Provide a visible, clickable QR code for payments on the account summary and ensure it displays nicely across screen sizes.
- Group the account-updated timestamp and QR into a single right-side area for clearer layout and improved UX.

### Description
- Added HTML markup in `naseAkce.html` to wrap the account timestamp and a clickable QR image in a new `.account-side` container and included an anchor that opens the full-size `images/qr_code.jpg`.
- Introduced new CSS rules in `assets/css/nase-akce.css` for `.account-side`, `.account-qr-link`, and `.account-qr` to style the QR card, borders, shadow, sizing, and alignment.
- Updated responsive rules to include `.account-side` so the QR and timestamp stack properly on small screens and set `.account-side` to full width under `@media` breakpoints.

### Testing
- No automated tests were run for this UI/layout change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27f18dbc98832fb30cbee0842af875)