### PR TITLE
Redesign support box and add accessible QR modal

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -3619,42 +3619,246 @@ input[type="button"],
 
 /* Homepage support QR box */
 .support-box {
-  display: flex;
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: space-between;
-  gap: 1.25em;
-  margin-top: 1.2em;
-  padding: 1em 1.2em;
-  background: rgba(255, 255, 255, 0.94);
-  border: 1px solid rgba(240, 79, 106, 0.18);
+  gap: clamp(1.25em, 4vw, 2.75em);
+  max-width: 48em;
+  margin: 1.4em auto 2.2em;
+  padding: clamp(1.35em, 3vw, 2.2em);
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(255, 246, 248, 0.96));
+  border: 1px solid rgba(240, 79, 106, 0.22);
 }
 
-.support-box__text {
-  font-size: 1.05em;
-  line-height: 1.35;
+.support-box::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0.45em;
+  background: linear-gradient(180deg, var(--heja-accent), #ffce00, #7bd0c1);
 }
 
-.support-box__qr-link {
+.support-box::after {
+  content: "";
+  position: absolute;
+  right: -4.5em;
+  bottom: -5em;
+  width: 13em;
+  height: 13em;
+  background: radial-gradient(circle, rgba(240, 79, 106, 0.16), rgba(240, 79, 106, 0));
+  pointer-events: none;
+}
+
+.support-box__content,
+.support-box__qr-button {
+  position: relative;
+  z-index: 1;
+}
+
+.support-box__eyebrow {
+  margin: 0 0 0.45em;
+  color: var(--heja-accent);
+  font-size: 0.78em;
+  font-weight: 900;
+  letter-spacing: 0.16em;
+  line-height: 1.3;
+  text-transform: uppercase;
+}
+
+#main .support-box h2 {
   display: block;
-  flex: 0 0 auto;
-  line-height: 0;
+  margin: 0 0 0.45em;
+}
+
+.support-box__content p:last-of-type {
+  margin-bottom: 0.9em;
+}
+
+.support-box__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45em;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.support-box__tags li {
+  margin: 0;
+  padding: 0.3em 0.75em;
+  border: 1px solid rgba(240, 79, 106, 0.26);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.74);
+  color: #333333;
+  font-size: 0.8em;
+  font-weight: 800;
+  letter-spacing: 0.02em;
+}
+
+.support-box__qr-button {
+  display: grid;
+  justify-items: center;
+  gap: 0.65em;
+  width: 11.5em;
+  height: auto;
+  min-height: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+  color: #222222 !important;
+  cursor: zoom-in;
+  font: inherit;
+  line-height: 1.2;
+  overflow: visible;
+  text-align: center;
+  text-overflow: clip;
+  text-transform: none;
+  letter-spacing: 0;
+  white-space: normal;
+}
+
+.support-box__qr-button:hover,
+.support-box__qr-button:focus {
+  background: transparent;
+  box-shadow: none;
+  color: var(--heja-accent-hover) !important;
+}
+
+.support-box__qr-button:focus-visible {
+  outline: 2px dashed var(--heja-accent-hover);
+  outline-offset: 0.45em;
+}
+
+.support-box__qr-button span {
+  font-size: 0.78em;
+  font-weight: 800;
 }
 
 .support-box__qr {
   display: block;
-  width: 5.25em;
-  height: 5.25em;
-  padding: 0.3em;
+  width: 9.25em;
+  height: 9.25em;
+  padding: 0.45em;
   border: 1px solid rgba(88, 88, 88, 0.16);
-  border-radius: 8px;
+  border-radius: 14px;
   background: #ffffff;
   object-fit: contain;
-  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.14);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.16);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.support-box__qr-button:hover .support-box__qr,
+.support-box__qr-button:focus .support-box__qr {
+  transform: scale(1.035);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.2);
+}
+
+.qr-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 10003;
+  display: grid;
+  place-items: center;
+  padding: 1.25em;
+  background: rgba(17, 17, 17, 0.72);
+  backdrop-filter: blur(3px);
+}
+
+.qr-modal[hidden] {
+  display: none;
+}
+
+.qr-modal__panel {
+  position: relative;
+  width: min(30em, 100%);
+  padding: clamp(1.25em, 4vw, 2em);
+  border-radius: 12px;
+  background: #ffffff;
+  box-shadow: 0 22px 60px rgba(0, 0, 0, 0.38);
+  text-align: center;
+}
+
+#main .qr-modal__panel h2 {
+  display: block;
+  margin: 0 2em 0.7em;
+}
+
+#main .qr-modal__panel h2::after {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.qr-modal__image {
+  display: block;
+  width: min(72vw, 20em);
+  height: min(72vw, 20em);
+  margin: 0 auto 1em;
+  padding: 0.65em;
+  border: 1px solid rgba(88, 88, 88, 0.16);
+  border-radius: 16px;
+  background: #ffffff;
+  object-fit: contain;
+  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.16);
+}
+
+.qr-modal__panel p {
+  margin: 0;
+}
+
+.qr-modal__close {
+  position: absolute;
+  top: 0.7em;
+  right: 0.7em;
+  width: 2.35em;
+  height: 2.35em;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(240, 79, 106, 0.1);
+  box-shadow: none;
+  color: #222222 !important;
+  font-size: 1.25em;
+  letter-spacing: 0;
+  line-height: 2.2em;
+  overflow: hidden;
+  text-align: center;
+  text-transform: none;
+  white-space: normal;
+}
+
+.qr-modal__close:hover,
+.qr-modal__close:focus {
+  background: rgba(240, 79, 106, 0.18);
+  box-shadow: none;
+  color: var(--heja-accent-hover) !important;
+}
+
+body.qr-modal-open {
+  overflow: hidden;
 }
 
 @media screen and (max-width: 736px) {
   .support-box {
-    align-items: flex-start;
-    flex-direction: column;
+    grid-template-columns: 1fr;
+    justify-items: center;
+    text-align: center;
+  }
+
+  .support-box::before {
+    inset: 0 0 auto 0;
+    width: auto;
+    height: 0.45em;
+  }
+
+  .support-box__tags {
+    justify-content: center;
+  }
+
+  .support-box__qr-button {
+    width: 100%;
   }
 }
+

--- a/index.html
+++ b/index.html
@@ -65,13 +65,31 @@
  						</section>
 
 						<section class="box support-box" aria-label="Podpora kapely">
-							<div class="support-box__text">
-								<strong>Podpořte nás příspěvkem na rozvoj kapely</strong>
+							<div class="support-box__content">
+								<p class="support-box__eyebrow">Dobrovolný kapelní doping</p>
+								<h2>Podpořte Heja Boys</h2>
+								<p>Jestli nám chcete přihodit něco na rozvoj kapely, nahrávání, koncerty, struny, benzín nebo jiné existenční rekvizity, použijte QR platbu.</p>
+								<ul class="support-box__tags" aria-label="Na co příspěvek pomůže">
+									<li>nahrávání</li>
+									<li>koncerty</li>
+									<li>struny</li>
+									<li>kapelní chaos</li>
+								</ul>
 							</div>
-							<a href="images/qr_code.jpg" class="support-box__qr-link" target="_blank" rel="noopener" aria-label="Otevřít QR kód pro podporu kapely v plné velikosti">
+							<button type="button" class="support-box__qr-button" aria-haspopup="dialog" aria-controls="qr-modal" aria-label="Zvětšit QR kód pro podporu kapely">
 								<img src="images/qr_code.jpg" alt="QR kód pro příspěvek na rozvoj kapely" class="support-box__qr" />
-							</a>
+								<span>Kliknutím zvětšíš QR kód</span>
+							</button>
 						</section>
+
+						<div class="qr-modal" id="qr-modal" role="dialog" aria-modal="true" aria-labelledby="qr-modal-title" hidden>
+							<div class="qr-modal__panel" role="document">
+								<button type="button" class="qr-modal__close" aria-label="Zavřít zvětšený QR kód">&times;</button>
+								<h2 id="qr-modal-title">QR platba pro podporu kapely</h2>
+								<img src="images/qr_code.jpg" alt="Zvětšený QR kód pro příspěvek na rozvoj kapely" class="qr-modal__image" />
+								<p>Po naskenování můžete poslat dobrovolný příspěvek. Děkujeme!</p>
+							</div>
+						</div>
 
  						<section class="tiles">
 							<article>
@@ -157,6 +175,45 @@
 				document.addEventListener('DOMContentLoaded', function () {
 					const API = 'https://hejaboys.pythonanywhere.com/api/akce?public=true';
 					const cont = document.getElementById('upcoming-content');
+					const qrModal = document.getElementById('qr-modal');
+					const qrButton = document.querySelector('.support-box__qr-button');
+					const qrClose = qrModal ? qrModal.querySelector('.qr-modal__close') : null;
+					let lastFocusedElement = null;
+
+					function openQrModal() {
+						if (!qrModal) return;
+						lastFocusedElement = document.activeElement;
+						qrModal.hidden = false;
+						document.body.classList.add('qr-modal-open');
+						if (qrClose) qrClose.focus();
+					}
+
+					function closeQrModal() {
+						if (!qrModal || qrModal.hidden) return;
+						qrModal.hidden = true;
+						document.body.classList.remove('qr-modal-open');
+						if (lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
+							lastFocusedElement.focus();
+						}
+					}
+
+					if (qrButton) {
+						qrButton.addEventListener('click', openQrModal);
+					}
+
+					if (qrClose) {
+						qrClose.addEventListener('click', closeQrModal);
+					}
+
+					if (qrModal) {
+						qrModal.addEventListener('click', function (event) {
+							if (event.target === qrModal) closeQrModal();
+						});
+					}
+
+					document.addEventListener('keydown', function (event) {
+						if (event.key === 'Escape') closeQrModal();
+					});
 
 					function renderUpcoming(html) {
 						if (cont) cont.innerHTML = html;


### PR DESCRIPTION
### Motivation
- Improve the visibility and usability of the homepage support/QR area by modernizing styling and enabling users to view a larger QR code without leaving the page.
- Provide an accessible, keyboard-friendly way to enlarge and close the QR image for mobile and desktop users.

### Description
- Reworked the support area by converting `.support-box` from a flex layout to a grid and applying updated layout, spacing, gradient, border, shadow and decorative pseudo-elements, and updated sizing for the QR artwork in `assets/css/main.css`.
- Introduced new content structure and copy in `index.html` including `div.support-box__content`, an eyebrow line, `h2`, tag list (`.support-box__tags`) and replaced the external link with a `button.support-box__qr-button` that contains the QR image and helper text.
- Added a modal dialog markup (`.qr-modal`, `.qr-modal__panel`, `.qr-modal__close`, `.qr-modal__image`) to `index.html` to display an enlarged QR code and corresponding CSS for modal presentation, focus styling, and `body.qr-modal-open` to prevent background scroll.
- Implemented interactive behavior in `index.html` JavaScript to open/close the modal, restore focus to the triggering element, handle backdrop clicks and the `Escape` key, and wire up the button and close control.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28105ba900832f93272e5722dca955)